### PR TITLE
Add tls inspector tsc stats

### DIFF
--- a/cli/develop.h
+++ b/cli/develop.h
@@ -250,6 +250,7 @@ private:
 			                obj.nat46clat_lan_handle,
 			                obj.nat46clat_wan_handle,
 			                obj.balancer_handle,
+			                obj.tls_inspector_ingress_handle,
 			                obj.balancer_icmp_reply_handle,
 			                obj.balancer_icmp_forward_handle,
 			                obj.route_tunnel_handle4,
@@ -278,6 +279,7 @@ private:
 		CountersArray nat46clat_lan_handle{};
 		CountersArray nat46clat_wan_handle{};
 		CountersArray balancer_handle{};
+		CountersArray tls_inspector_ingress_handle{};
 
 		CountersArray balancer_icmp_reply_handle{};
 		CountersArray balancer_icmp_forward_handle{};
@@ -334,6 +336,7 @@ private:
 		                 "nat46clat_lan",
 		                 "nat46clat_wan",
 		                 "balancer",
+		                 "tls_inspector_ingress",
 		                 "balancer_icmp_reply",
 		                 "balancer_icmp_forward",
 		                 "route_tunnel4",

--- a/cli/show.h
+++ b/cli/show.h
@@ -890,6 +890,7 @@ static const std::map<std::string, uint32_t> counter_name_to_offset = {
         {"nat46clat_lan_handle", offsetof(tsc_base_values, nat46clat_lan_handle)},
         {"nat46clat_wan_handle", offsetof(tsc_base_values, nat46clat_wan_handle)},
         {"balancer_handle", offsetof(tsc_base_values, balancer_handle)},
+        {"tls_inspector_ingress_handle", offsetof(tsc_base_values, tls_inspector_ingress_handle)},
         {"balancer_icmp_reply_handle", offsetof(tsc_base_values, balancer_icmp_reply_handle)},
         {"balancer_icmp_forward_handle", offsetof(tsc_base_values, balancer_icmp_forward_handle)},
         {"route_tunnel_handle4", offsetof(tsc_base_values, route_tunnel_handle4)},

--- a/common/tsc_deltas.h
+++ b/common/tsc_deltas.h
@@ -123,6 +123,7 @@ struct alignas(2 * RTE_CACHE_LINE_SIZE) tsc_deltas
 		                nat46clat_lan_handle,
 		                nat46clat_wan_handle,
 		                balancer_handle,
+		                tls_inspector_ingress_handle,
 		                balancer_icmp_reply_handle,
 		                balancer_icmp_forward_handle,
 		                route_tunnel_handle4,


### PR DESCRIPTION
## Summary
- include tls inspector counters in tsc deltas
- expose tls inspector stats via CLI

## Testing
- `clang-format -i common/tsc_deltas.h cli/develop.h cli/show.h`
- `meson test -C build_unittest` *(fails: `meson: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68611492bce483268d6c12ae6a204cf4